### PR TITLE
Add error message to console on debugging parsing error

### DIFF
--- a/src/gui/components/CPUDebugger.jsx
+++ b/src/gui/components/CPUDebugger.jsx
@@ -413,8 +413,13 @@ export default class CPUDebugger extends PureComponent {
 			bus.emit("run-enabled", true);
 		}, this.state._delay);
 
-		this._cpu.step();
-		this._updateState("step");
+		try {
+			this._cpu.step();
+			this._updateState("step");
+		} catch (e) {
+			const message = testContext.javascript.buildHTMLError(e);
+			this.setState({ _error: message });
+		}
 	};
 
 	_onReset = () => {


### PR DESCRIPTION
Small change, but when I was playing the level that teaches branching in 6502, if I tried using an instruction that was not available at the time (unconditional jump, JMP), the step-by-step debugger silently failed and behaved oddly.

Now, at least it makes it crystal clear that the error is in parsing the specific line that contains the still-not-taught instruction. 

Could make it even more explicit and precise by having a set A with all instructions and another one with the subset B of the instructions available up until that level and then checking if some instruction the user wrote is in A (set with all) but not in B (subset with available ones) yet