### PR TITLE
Disable foldKeymap in the codemirror editor.

### DIFF
--- a/src/gui/components/CodeEditor.jsx
+++ b/src/gui/components/CodeEditor.jsx
@@ -209,6 +209,9 @@ export default class CodeEditor extends PureComponent {
 					height="100%"
 					theme={this._getThemeExtension()}
 					readOnly={!isEditionEnabled}
+					basicSetup={{
+						foldKeymap: false,
+					}}
 					extensions={LANGUAGES[language](filePath, extraLangOptions)}
 					onChange={this._setCode}
 					autoFocus


### PR DESCRIPTION
related to #27 
I'm not a JS dev, so feel free to point out how to do this properly and I'll amend the PR.
