### PR TITLE
FIX: use hex notation in test error message

### DIFF
--- a/src/data/levels/$tests/apu.js
+++ b/src/data/levels/$tests/apu.js
@@ -1,4 +1,5 @@
-const { evaluate, byte, lodash: _ } = $;
+const { evaluate, testHelpers, byte, lodash: _ } = $;
+const { toHex } = testHelpers;
 
 let mainModule, Console;
 before(async () => {
@@ -204,9 +205,10 @@ it("connects the audio registers to CPU memory (<reads>)", () => {
       try {
         expect(result).to.equal(returnValue);
       } catch (e) {
-        const addressStr = `0x${address.toString(16).padStart(4, "0")}`;
         throw new Error(
-          `\`cpuMemory.read(${addressStr})\` did call \`${key}.onRead()\`, but it didn't return the value that the register provided.`
+          `\`cpuMemory.read(${toHex(
+            address
+          )})\` did call \`${key}.onRead()\`, but it didn't return the value that the register provided.`
         );
       }
     } else {

--- a/src/data/levels/$tests/bus.js
+++ b/src/data/levels/$tests/bus.js
@@ -1,4 +1,5 @@
-const { evaluate, filesystem, byte } = $;
+const { evaluate, filesystem, testHelpers, byte } = $;
+const { toHex } = testHelpers;
 
 let mainModule;
 before(async () => {
@@ -75,7 +76,7 @@ it("can read from RAM ($0000-$07FF)", () => {
   for (let i = 0; i < 2048; i++) {
     const value = byte.random();
     memory.ram[i] = value;
-    expect(memory.read(i)).to.equalN(value, `read(${i})`);
+    expect(memory.read(i)).to.equalN(value, `read(${toHex(i)})`);
   }
 })({
   locales: {
@@ -91,7 +92,7 @@ it("reading RAM mirror results in <RAM reads>", () => {
   for (let i = 0x0800; i < 0x0800 + 0x1800; i++) {
     const value = byte.random();
     memory.ram[(i - 0x0800) % 0x0800] = value;
-    expect(memory.read(i)).to.equalN(value, `read(${i})`);
+    expect(memory.read(i)).to.equalN(value, `read(${toHex(i)})`);
   }
 })({
   locales: {
@@ -162,13 +163,14 @@ it("can read from the mapper ($4020-$FFFF)", () => {
   const memory = new CPUMemory();
   const random = byte.random();
   const mapper = {
-    cpuRead: (address) => address * random,
+    cpuRead: (address) => byte.toU8(address * random),
     cpuWrite: () => {},
   };
   memory.onLoad({}, {}, mapper, []);
 
   for (let i = 0x4020; i <= 0xffff; i++) {
-    expect(memory.read(i)).to.equalHex(i * random, `read(${i})`);
+    const expected = byte.toU8(i * random);
+    expect(memory.read(i)).to.equalHex(expected, `read(${toHex(i)})`);
   }
 })({
   locales: {

--- a/src/data/levels/$tests/ppu.js
+++ b/src/data/levels/$tests/ppu.js
@@ -276,7 +276,10 @@ it("`PPUMemory`: connects the mapper (<reads>)", () => {
   ppu.memory.onLoad(dummyCartridge, mapper);
 
   for (let i = 0x0000; i <= 0x1fff; i++) {
-    expect(ppu.memory.read(i)).to.equalHex(i * random, `read(${i})`);
+    expect(ppu.memory.read(i)).to.equalHex(
+      i * random,
+      `read(0x${i.toString(16).padStart(4, "0")}})`
+    );
   }
 })({
   locales: {

--- a/src/data/levels/$tests/ppu.js
+++ b/src/data/levels/$tests/ppu.js
@@ -1,4 +1,5 @@
-const { evaluate, byte } = $;
+const { evaluate, testHelpers, byte } = $;
+const { toHex } = testHelpers;
 
 let mainModule, Console;
 before(async () => {
@@ -270,16 +271,14 @@ it("`PPUMemory`: connects the mapper (<reads>)", () => {
 
   const random = byte.random();
   const mapper = {
-    ppuRead: (address) => address * random,
+    ppuRead: (address) => byte.toU8(address * random),
     ppuWrite: () => {},
   };
   ppu.memory.onLoad(dummyCartridge, mapper);
 
   for (let i = 0x0000; i <= 0x1fff; i++) {
-    expect(ppu.memory.read(i)).to.equalHex(
-      i * random,
-      `read(0x${i.toString(16).padStart(4, "0")}})`
-    );
+    const expected = byte.toU8(i * random);
+    expect(ppu.memory.read(i)).to.equalHex(expected, `read(${toHex(i)})`);
   }
 })({
   locales: {
@@ -399,9 +398,10 @@ it("connects the video registers to CPU memory (<reads>)", () => {
     try {
       expect(result).to.equal(returnValue);
     } catch (e) {
-      const addressStr = `0x${address.toString(16).padStart(4, "0")})`;
       throw new Error(
-        `\`cpuMemory.read(${addressStr})\` did call \`${name}.onRead()\`, but it didn't return the value that the register provided.`
+        `\`cpuMemory.read(${toHex(
+          address
+        )})\` did call \`${name}.onRead()\`, but it didn't return the value that the register provided.`
       );
     }
   });

--- a/src/terminal/commands/test/context/testHelpers.js
+++ b/src/terminal/commands/test/context/testHelpers.js
@@ -15,4 +15,8 @@ function newRom(prgBytes = [], header = newHeader()) {
 	return bytes;
 }
 
-export default { newHeader, newRom };
+function toHex(n, length = 4) {
+	return `0x${n.toString(16).padStart(length, "0")}`;
+}
+
+export default { newHeader, newRom, toHex };


### PR DESCRIPTION
Hi @afska, I continue my journey on your excellent game 🙌

But I was stuck on some error on chapter "5b.4". I implemented my class PPUMemory, but got a test that failed:

<img width="572" height="74" alt="image" src="https://github.com/user-attachments/assets/d0b0a5b4-d517-451b-8477-4b4662aad377" />

Since PPUMemory range from 0x0000 to 0x3FFF, I really could not understand why the test was trying to read at 0x8191

So I read the code of the test and saw that its error message was using decimal notation instead of hexadecimal notation. So I fixed the test, and now the error is more easy to understand:

<img width="602" height="74" alt="image" src="https://github.com/user-attachments/assets/8b62d61d-37ee-4e4d-96a3-705f7cd42bd7" />


And yeah, with the "good" error message, I instantly understood the error in my code...
<img width="494" height="148" alt="image" src="https://github.com/user-attachments/assets/5c5eff7f-07a9-4abc-813f-2ef972e5dc33" />

I think I saw the same "bug" in the tests of bus.

Feel free to comment/edit my PR if you have a cleaner way to do it.

Note: line breaks in my PR are done by husky 🐶