### PR TITLE
Fixes a minor issue with the code snippet on 5b.10

### DIFF
--- a/src/data/levels/05b_PPU/10_Backgrounds 2-2 - Using Attribute tables/chat/en.yml
+++ b/src/data/levels/05b_PPU/10_Backgrounds 2-2 - Using Attribute tables/chat/en.yml
@@ -36,7 +36,7 @@ main:
         const colorIndex = tile.getColorIndex(xx);
         const color =
           colorIndex > 0 ? this.ppu.getColor(paletteId, colorIndex) : this.ppu.getColor(0, 0);
-        this.plot(x + xx, y, color);
+        this.ppu.plot(x + xx, y, color);
       }```
   - note that when the color index is 0, a <backdrop color> is rendered instead (located at the first index of the first palette)
   responses:

--- a/src/data/levels/05b_PPU/10_Backgrounds 2-2 - Using Attribute tables/chat/es.yml
+++ b/src/data/levels/05b_PPU/10_Backgrounds 2-2 - Using Attribute tables/chat/es.yml
@@ -36,7 +36,7 @@ main:
         const colorIndex = tile.getColorIndex(xx);
         const color =
           colorIndex > 0 ? this.ppu.getColor(paletteId, colorIndex) : this.ppu.getColor(0, 0);
-        this.plot(x + xx, y, color);
+        this.ppu.plot(x + xx, y, color);
       }```
   - ten en cuenta que cuando el índice de color es 0, se renderiza un <backdrop color> en su lugar (ubicado en el primer índice de la primera paleta)
   responses:


### PR DESCRIPTION
In 5b.10 the code snippet provided to place into BackgroundRenderer has a very minor mistake where it was calling a .plot function on the BackgroundRenderer but it should have been on the ppu.

this fixes it
<img width="872" height="232" alt="vivaldi_ePWgpZAjVy" src="https://github.com/user-attachments/assets/6876518d-60c7-47d7-89cf-777f64b3ebda" />
<img width="762" height="244" alt="vivaldi_30XLrsGTXH" src="https://github.com/user-attachments/assets/e92be80e-0129-4f87-a766-2ff6249470f7" />
